### PR TITLE
Updated  to support gemini urls with port # at the end

### DIFF
--- a/gcat
+++ b/gcat
@@ -26,9 +26,13 @@ parsed_url = urllib.parse.urlparse(url)
 if parsed_url.scheme != "gemini":
     print("Sorry, Gemini links only.")
     sys.exit(1)
+if parsed_url.port is not None:
+    useport = parsed_url.port
+else:
+    useport = 1965
 # Do the Gemini transaction
 while True:
-    s = socket.create_connection((parsed_url.netloc, 1965))
+    s = socket.create_connection((parsed_url.hostname, useport))
     context = ssl.SSLContext()
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Updated socket create connection to support gemini urls with non-standard (1965) ports,
ex: gemini://peteyboy.freeshell.org:32056
Wasn't working before, would throw error when unable to connect on port 1965

Tested vs above, plus gemini://gemini.circumlunar.space, and gemini://mozz.us/jetforce

Looks like it works.
